### PR TITLE
fix: Fixed store needing a initial value even when undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ const { store, useStore } = createStore(0, getStore)
 // Works as expected
 store.increment()
 ```
+
+## Creating a store without an initial value
+
+As in React's useState, if a value is not informed on initialization, the
+Store's value will be `T | undefined`
+
+```typescript
+const {
+	store,   // 'string | undefined'
+	useStore // accepts string and undefined as parameters
+} = createStore<string>()
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,11 @@ function getStore<T>(initialValue: T): Store<T> {
 	return new Store(initialValue)
 }
 
+type CreateStore<T, W extends Writable<T> = Store<T>> = {
+	store: W;
+	useStore: () => [T, Subscriber<T>];
+}
+
 /**
  * Creates a new store with a related useStore hook
  * @param initialValue Initial store value
@@ -67,9 +72,24 @@ function getStore<T>(initialValue: T): Store<T> {
  */
 export function createStore<T, W extends Writable<T> = Store<T>>(
 	initialValue: T,
+	writable?: (v: T) => W,
+): CreateStore<T, W>
+
+/**
+ * Creates a new store with a related useStore hook
+ *
+ * Since there is no initial value, undefined will be mixed with
+ * the store's T type
+ *
+ * @returns A store and a useStore hook for that store
+ */
+export function createStore<T = undefined>(): CreateStore<T|undefined>
+
+export function createStore<T, W extends Writable<T> = Store<T>>(
+	initialValue?: T,
 	writable: (v: T) => W = getStore as unknown as (v: T) => W,
-) {
-	const store = writable(initialValue)
+): CreateStore<T, W> {
+	const store = writable(initialValue as T)
 
 	return {
 		store,


### PR DESCRIPTION
-- fixed store needing a initial value even when said value is undefined
-- fixed type system not infering that if a value was not provided on the 'createStore' it means it should be T|undefined
-- updated README.md